### PR TITLE
Update version to 1.1.1 and enhance JWT_ALLAUTH_USER_ATTRIBUTES confi…

### DIFF
--- a/docs/source/configuration.settings_py.rst
+++ b/docs/source/configuration.settings_py.rst
@@ -19,7 +19,7 @@ Configure these variables in the ``settings.py`` file of your project.
 
     - ``JWT_ALLAUTH_REFRESH_TOKEN_AS_COOKIE`` - whether to send refresh tokens as HTTP-only cookies instead of in the JSON response payload (default: ``True``).
 
-    - ``JWT_ALLAUTH_USER_ATTRIBUTES`` - list of user attribute paths to include in refresh tokens (default: ``[]``). Each string should be a dot-separated path to the attribute (e.g., ``'address'``, ``'profile.age'``). The 'role' attribute is automatically included and should not be specified.
+    - ``JWT_ALLAUTH_USER_ATTRIBUTES`` - dictionary mapping output claim names to dot-separated user attribute paths to include in refresh tokens (default: ``{}``). Example: ``{"organization_id": "organization.id", "area_id": "area.id"}``. The 'role' attribute is automatically included and should not be specified, and output claim names must be unique.
 
 - Redirection URLs
 

--- a/docs/source/refresh_token.rst
+++ b/docs/source/refresh_token.rst
@@ -12,8 +12,8 @@ compromised or outdated refresh tokens can be promptly invalidated when necessar
 The following constants should be included in the settings.py file:
 
     - ``JWT_ALLAUTH_REFRESH_TOKEN`` - refresh token class (default: ``jwt_allauth.tokens.tokens.RefreshToken``).
-    
-    - ``JWT_ALLAUTH_USER_ATTRIBUTES`` - list of user attribute paths to include in tokens (default: ``[]``).
+
+    - ``JWT_ALLAUTH_USER_ATTRIBUTES`` - dictionary mapping output claim names to user attribute paths to include in tokens (default: ``{}``). Example: ``{"organization_id": "organization.id", "area_id": "area.id"}``. The 'role' attribute is automatically included and should not be specified.
 
     - ``JWT_ALLAUTH_REFRESH_TOKEN_AS_COOKIE`` - whether to send refresh tokens as HTTP-only cookies instead of in the JSON response payload (default: ``True``).
 
@@ -33,25 +33,3 @@ the complete user object in your view methods, you should use the :func:`~jwt_al
         def get(self, request):
             # request.user is now the complete user object
             return Response({"username": request.user.username})
-
-Example:
-
-.. code-block:: python
-
-    from jwt_allauth.tokens.tokens import RefreshToken as DefaultRefreshToken
-
-    class RefreshToken(DefaultRefreshToken):
-        def set_user_attributes(self, user):
-            """Add user attributes defined in JWT_ALLAUTH_USER_ATTRIBUTES setting to token payload."""
-            # Implementation automatically includes user attributes from settings
-            # Note: 'role' is always included separately and should not be in JWT_ALLAUTH_USER_ATTRIBUTES
-
-        def set_user_permissions(self, user):
-            self.payload['permissions'] = user.permissions
-
-        @classmethod
-        def for_user(cls, user, request=None, enabled=True):
-            token = super().for_user(user)
-            token.set_user_attributes(user)
-            token.set_user_permissions(user)
-            return token

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+Version 1.1.1
+-------------
+
+Released: October 11, 2025
+
+Breaking Change
+~~~~~~~~~~~~~~~
+
+- ``JWT_ALLAUTH_USER_ATTRIBUTES`` now expects a dictionary mapping output claim names to user attribute paths (e.g., ``{"organization_id": "organization.id"}``) instead of a list of paths. This change prevents duplicate final attribute names (e.g., multiple ``id`` keys) in JWT payloads. The previous list format is still accepted for backward compatibility, but it is deprecated and may be removed in a future release.
+
 Version 1.1.0
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-jwt-allauth"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
     {name = "Fernando Castellanos", email = "fcastellanos.dev@gmail.com"},
 ]

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -467,7 +467,7 @@ class TokenTests(TestsMixin):
         self.assertFalse(token_entry.is_tablet)
         self.assertFalse(token_entry.is_bot)
 
-    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES=['email', 'username'])
+    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES={'email': 'email', 'username': 'username'})
     def test_set_user_attributes_with_valid_user_attributes(self):
         """Verify that set_user_attributes correctly adds configured user attributes to token payload"""
         token = RefreshTokenClass()
@@ -483,7 +483,7 @@ class TokenTests(TestsMixin):
         self.assertEqual(token.payload['email'], 'test@example.com')
         self.assertEqual(token.payload['username'], 'testuser')
 
-    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES=['profile.role', 'profile.department.name'])
+    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES={'role': 'profile.role', 'name': 'profile.department.name'})
     def test_set_user_attributes_with_nested_attribute_paths(self):
         """Verify that set_user_attributes correctly handles nested attribute paths"""
         token = RefreshTokenClass()
@@ -503,7 +503,7 @@ class TokenTests(TestsMixin):
         with self.assertRaises(ValueError):
             token.set_user_attributes(user)
 
-    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES=['email', 'nonexistent_attr', 'profile.missing'])
+    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES={'email': 'email', 'nonexistent_attr': 'nonexistent_attr', 'missing': 'profile.missing'})
     def test_set_user_attributes_with_missing_attributes(self):
         """Verify that set_user_attributes handles missing or None attributes gracefully"""
         token = RefreshTokenClass()
@@ -519,7 +519,7 @@ class TokenTests(TestsMixin):
         self.assertNotIn('nonexistent_attr', token.payload)
         self.assertNotIn('missing', token.payload)
 
-    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES=['role', 'email'])
+    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES={'role': 'role', 'email': 'email'})
     def test_set_user_attributes_prevents_role_attribute_collision(self):
         """Verify that set_user_attributes does not overwrite existing 'role' attribute"""
         token = RefreshTokenClass()
@@ -534,7 +534,7 @@ class TokenTests(TestsMixin):
         with self.assertRaises(ValueError):
             token.set_user_attributes(user)
 
-    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES=['email', 'username', 'profile.title'])
+    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES={'email': 'email', 'username': 'username', 'title': 'profile.title'})
     def test_for_user_includes_user_attributes_in_token(self):
         """Verify that RefreshToken.for_user method calls set_user_attributes and includes user attributes"""
         # Use a real persisted user to satisfy whitelist serializer

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -503,7 +503,8 @@ class TokenTests(TestsMixin):
         with self.assertRaises(ValueError):
             token.set_user_attributes(user)
 
-    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES={'email': 'email', 'nonexistent_attr': 'nonexistent_attr', 'missing': 'profile.missing'})
+    @override_settings(JWT_ALLAUTH_USER_ATTRIBUTES={
+        'email': 'email', 'nonexistent_attr': 'nonexistent_attr', 'missing': 'profile.missing'})
     def test_set_user_attributes_with_missing_attributes(self):
         """Verify that set_user_attributes handles missing or None attributes gracefully"""
         token = RefreshTokenClass()


### PR DESCRIPTION
…guration

- Bumped version in pyproject.toml to 1.1.1.
- Updated documentation to reflect the change in JWT_ALLAUTH_USER_ATTRIBUTES from a list to a dictionary format, allowing for unique output claim names.
- Adjusted the RefreshToken class to support the new dictionary format while maintaining backward compatibility with the list format.
- Modified tests to validate the new configuration and ensure proper handling of user attributes.