### PR TITLE
Bump version to 1.2.3 and configure MIGRATION_MODULES for jwt_allauth…

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,7 +29,7 @@ if hasattr(django, 'setup'):
 project = 'JWT Allauth'
 copyright = '2025, Fernando Castellanos'
 author = 'Fernando Castellanos'
-release = '1.2.2'
+release = '1.2.3'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -25,6 +25,19 @@ This will create a new Django project called "myproject" with JWT Allauth pre-co
     python manage.py migrate
     python manage.py runserver
 
+Projects created via ``jwt-allauth startproject`` are configured to store ``jwt_allauth`` migrations inside your project codebase via Django's ``MIGRATION_MODULES`` setting. This is especially useful in Docker environments where your project source code is persisted (and committed to git) but ``site-packages`` is ephemeral.
+
+The generated migration files will live under:
+
+.. code-block:: text
+
+    myproject/
+        myproject/
+            migrations_external/
+                jwt_allauth/
+                    0001_initial.py
+                    ...
+
 Available options:
 
 - ``--email=True`` - Enables email configuration in the project
@@ -93,7 +106,30 @@ Add the following to your ``urls.py`` file.
 
 Run migrations.
 
+To make migrations persistent across environments (recommended for Docker), configure local migration modules for ``jwt_allauth`` using ``MIGRATION_MODULES``.
+
+1) Create the local migrations package inside your Django project module (replace ``myproject`` with your project module name):
+
+.. code-block:: text
+
+    myproject/
+        myproject/
+            migrations_external/
+                __init__.py
+                jwt_allauth/
+                    __init__.py
+
+2) Add this to your ``settings.py``:
+
 .. code-block:: python
+
+    MIGRATION_MODULES = {
+        'jwt_allauth': 'myproject.migrations_external.jwt_allauth',
+    }
+
+3) Generate and apply migrations:
+
+.. code-block:: bash
 
     python manage.py makemigrations jwt_allauth
     python manage.py migrate

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,21 @@
 Release Notes
 =============
 
+Version 1.2.3
+-------------
+
+Released: January 25, 2026
+
+Behavior and functionality
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Projects generated via ``jwt-allauth startproject`` now configure Django's ``MIGRATION_MODULES`` so that ``jwt_allauth`` migrations are stored inside the project codebase (under ``<project_module>/migrations_external/jwt_allauth``). This improves reliability in Docker/containerized deployments where ``site-packages`` is ephemeral.
+
+Documentation
+~~~~~~~~~~~~~
+
+- Updated installation documentation to explain how to configure ``MIGRATION_MODULES`` manually in existing projects to persist ``jwt_allauth`` migrations in version control.
+
 Version 1.2.2
 -------------
 

--- a/jwt_allauth/bin/jwt_allauth.py
+++ b/jwt_allauth/bin/jwt_allauth.py
@@ -68,13 +68,16 @@ def main():
             settings_path = os.path.join(target_dir, project_name, 'settings.py')
 
             # Modify settings.py to include JWT-allauth configuration
-            _modify_settings(settings_path, email_config)
+            _modify_settings(settings_path, email_config, project_name)
             print("✅ Added JWT Allauth configuration to settings.py")
 
             # Add urls.py configuration
             urls_path = os.path.join(target_dir, project_name, 'urls.py')
             _modify_urls(urls_path)
             print("✅ Added JWT Allauth URLs to urls.py")
+
+            _ensure_local_migration_modules(target_dir, project_name)
+            print("✅ Configured local migration modules")
 
             # Create templates directory if needed
             if email_config:
@@ -86,7 +89,7 @@ def main():
             print("\n✅ JWT Allauth project successfully created!")
             print("📋 Next steps:")
             print(f"   1. cd {target_dir}")
-            print(f"   2. python manage.py makemigrations")
+            print(f"   2. python manage.py makemigrations jwt_allauth")
             print(f"   3. python manage.py migrate")
             print(f"   4. python manage.py runserver")
 
@@ -111,7 +114,21 @@ def main():
 
     return 0
 
-def _modify_settings(settings_path, email_config):
+
+def _ensure_local_migration_modules(target_dir, project_name):
+    migrations_dir = os.path.join(target_dir, project_name, 'migrations_external', 'jwt_allauth')
+    os.makedirs(migrations_dir, exist_ok=True)
+
+    init_files = [
+        os.path.join(target_dir, project_name, 'migrations_external', '__init__.py'),
+        os.path.join(target_dir, project_name, 'migrations_external', 'jwt_allauth', '__init__.py'),
+    ]
+    for init_file in init_files:
+        if not os.path.exists(init_file):
+            with open(init_file, 'w') as f:
+                f.write('')
+
+def _modify_settings(settings_path, email_config, project_module=None):
     """Modify Django settings.py to include JWT Allauth configuration"""
     with open(settings_path, 'r') as f:
         settings_content = f.read()
@@ -241,6 +258,15 @@ EMAIL_VERIFIED_REDIRECT = None  # URL to redirect after email verification
 PASSWORD_RESET_REDIRECT = None  # URL for password reset form
 """
         settings_content += email_settings
+
+    if project_module and "MIGRATION_MODULES" not in settings_content:
+        migration_modules = f"""
+
+MIGRATION_MODULES = {{
+    'jwt_allauth': '{project_module}.migrations_external.jwt_allauth',
+}}
+"""
+        settings_content += migration_modules
 
     with open(settings_path, 'w') as f:
         f.write(settings_content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-jwt-allauth"
-version = "1.2.2"
+version = "1.2.3"
 authors = [
     {name = "Fernando Castellanos", email = "fcastellanos.dev@gmail.com"},
 ]

--- a/tests/test_startproject.py
+++ b/tests/test_startproject.py
@@ -43,7 +43,7 @@ MIDDLEWARE = [
             """)
 
         # Modify settings
-        _modify_settings(settings_path, email_config=True)
+        _modify_settings(settings_path, email_config=True, project_module='testproject')
 
         # Read the modified settings
         with open(settings_path, 'r') as f:
@@ -78,6 +78,10 @@ MIDDLEWARE = [
         self.assertIn("EMAIL_HOST_USER", content)
         self.assertIn("EMAIL_HOST_PASSWORD", content)
         self.assertIn("DEFAULT_FROM_EMAIL", content)
+
+        # Check if migration modules are configured
+        self.assertIn("MIGRATION_MODULES", content)
+        self.assertIn("testproject.migrations_external.jwt_allauth", content)
 
     def test_modify_urls(self):
         # Create a temporary urls file
@@ -138,6 +142,16 @@ urlpatterns = [
         self.assertEqual(args[0][2], self.project_name)
         self.assertEqual(args[0][3], self.project_dir)
 
+        # Check if local migration modules were created
+        migrations_dir = os.path.join(self.project_dir, self.project_name, 'migrations_external', 'jwt_allauth')
+        self.assertTrue(os.path.exists(migrations_dir))
+
+        # Check if settings.py includes MIGRATION_MODULES configuration
+        with open(settings_path, 'r') as f:
+            content = f.read()
+            self.assertIn("MIGRATION_MODULES", content)
+            self.assertIn("testproject.migrations_external.jwt_allauth", content)
+
     @patch('subprocess.run')
     def test_startproject_with_email(self, mock_run):
         # Mock subprocess.run to simulate django-admin startproject
@@ -172,6 +186,10 @@ urlpatterns = [
             content = f.read()
             self.assertIn("EMAIL_VERIFICATION = True", content)
             self.assertIn("EMAIL_BACKEND", content)
+
+        # Check if local migration modules were created
+        migrations_dir = os.path.join(self.project_dir, self.project_name, 'migrations_external', 'jwt_allauth')
+        self.assertTrue(os.path.exists(migrations_dir))
 
     @patch('subprocess.run')
     def test_startproject_error(self, mock_run):


### PR DESCRIPTION
… in startproject command

- Updated version from 1.2.2 to 1.2.3 in pyproject.toml and docs/source/conf.py
- Modified jwt-allauth startproject command to automatically configure MIGRATION_MODULES setting, storing jwt_allauth migrations in project codebase under <project_module>/migrations_external/jwt_allauth
- Added _ensure_local_migration_modules() function to create migration directories and __init__.py files
- Updated _modify_settings() to accept